### PR TITLE
fix comparison in line 112

### DIFF
--- a/aldor/aldor/src/macex.c
+++ b/aldor/aldor/src/macex.c
@@ -109,7 +109,7 @@ macexFiniFile()
 local void
 initMacDef(void)
 {
-	if (!fintMode == FINT_LOOP) macDefs = 0;
+	if (!(fintMode == FINT_LOOP)) macDefs = 0;
 }
  
  


### PR DESCRIPTION
!somebool == 2 is always false, as !somebool can only be 0 or 1.
changed to the obviously intended comparison.